### PR TITLE
Fixes #16. Set the root path to use the recipe resolver, so that the …

### DIFF
--- a/src/app/recipes/recipes-routing.module.ts
+++ b/src/app/recipes/recipes-routing.module.ts
@@ -10,7 +10,8 @@ import {RecipesResolverService} from "./recipes-resolver.service";
 const routes: Routes = [
   {
     path: '', component: RecipesComponent, canActivate: [AuthGuard], children: [
-      {path: '', component: RecipeStartComponent},
+      // {path: '', component: RecipeStartComponent},
+      {path: '', component: RecipeStartComponent, resolve: [RecipesResolverService]},
       {path: 'new', component: RecipeEditComponent},
       {path: ':id', component: RecipeDetailComponent, resolve: [RecipesResolverService]},
       {path: ':id/edit', component: RecipeEditComponent, resolve: [RecipesResolverService]}


### PR DESCRIPTION
…recipe-service cache has been populated, before the recipe-list component attempts to query.